### PR TITLE
ZON-1566: Make video rendition duration settable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.brightcove changes
 =======================
 
-2.6.14 (unreleased)
+2.7 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make video rendition duration attribute settable (ZON-1566).
 
 
 2.6.13 (2015-05-22)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.brightcove',
-    version='2.6.14.dev0',
+    version='2.7.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',
@@ -22,7 +22,7 @@ setup(
         'setuptools',
         'zeit.addcentral',
         'zeit.cms>=2.35.1.dev0',
-        'zeit.content.video>=2.4.0.dev0',
+        'zeit.content.video>=2.4.1',
         'zeit.solr>=2.2.0.dev0',
         'zope.cachedescriptors',
         'zope.component',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'setuptools',
         'zeit.addcentral',
         'zeit.cms>=2.35.1.dev0',
-        'zeit.content.video>=2.4.1',
+        'zeit.content.video>=2.4.1.dev0',
         'zeit.solr>=2.2.0.dev0',
         'zope.cachedescriptors',
         'zope.component',

--- a/src/zeit/brightcove/converter.py
+++ b/src/zeit/brightcove/converter.py
@@ -307,6 +307,19 @@ class Video(Converter):
             rs.append(vr)
         return tuple(rs)
 
+    @renditions.setter
+    def renditions(self, value):
+        rs = []
+        if not value:
+            value = ()
+        for rendition in value:
+            vr = dict(
+                url=rendition.url,
+                frameWidth=rendition.frame_width,
+                videoDuration=rendition.video_duration)
+            rs.append(vr)
+        self.data.setdefault('renditions', tuple(rs))
+
     @property
     def related(self):
         result = []

--- a/src/zeit/brightcove/tests/test_converter.py
+++ b/src/zeit/brightcove/tests/test_converter.py
@@ -183,15 +183,31 @@ class VideoConverterTest(zeit.brightcove.testing.BrightcoveTestCase):
             ['http://xml.zeit.de/online/2007/01/Somalia'],
             [x.uniqueId for x in related.related])
 
+    def test_renditions_should_be_converted_to_brightcove(self):
+        rendition = zeit.content.video.video.VideoRendition()
+        rendition.url = 'http://example.org/my_rendition'
+        rendition.frame_width = 720
+        rendition.video_duration = 68000
+        cmsobj = zeit.content.video.video.Video()
+        cmsobj.renditions = (rendition,)
+        video = Video.from_cms(cmsobj)
+
+        self.assertEqual(
+            'http://example.org/my_rendition', video.renditions[0].url)
+
+        self.assertEqual(720, video.renditions[0].frame_width)
+
+        self.assertEqual(68000, video.renditions[0].video_duration)
+
     def test_renditions_should_be_converted_to_cms(self):
         video = Video.find_by_id('1234')
         video.data['renditions'] = [{
-            'url': 'http:example.org/my_rendition',
+            'url': 'http://example.org/my_rendition',
             'frameWidth': 400,
             'videoDuration': 93000}]
         cmsobj = video.to_cms()
         self.assertEqual(
-            'http:example.org/my_rendition', cmsobj.renditions[0].url)
+            'http://example.org/my_rendition', cmsobj.renditions[0].url)
 
         self.assertEqual(400, cmsobj.renditions[0].frame_width)
 


### PR DESCRIPTION
Requires https://github.com/ZeitOnline/zeit.content.video/pull/2
