### PR TITLE
Fix `APIConnection.post()` for ``disabled`` write tokens.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ zeit.brightcove changes
 
 - Update to `zeit.cms >= 2.90`.
 
+- Fix `APIConnection.post()` for ``disabled`` write tokens.
+
 
 2.8.2 (2016-09-14)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,15 +4,13 @@ zeit.brightcove changes
 2.8.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Really disable writing for ``disabled`` write tokens.
 
 
 2.8.3 (2016-09-26)
 ------------------
 
 - Update to `zeit.cms >= 2.90`.
-
-- Fix `APIConnection.post()` for ``disabled`` write tokens.
 
 
 2.8.2 (2016-09-14)

--- a/src/zeit/brightcove/connection.py
+++ b/src/zeit/brightcove/connection.py
@@ -39,8 +39,9 @@ class APIConnection(object):
         return json.loads(text.translate(RESTRICTED_CHARACTERS_MAP))
 
     def post(self, command, **kwargs):
-        if self.write_token == 'invalid':
+        if self.write_token == 'disabled':
             log.info('POST %s disabled, no write token configured', command)
+            return
         params = dict(
             (key, value) for key, value in kwargs.items() if key and value)
         params['token'] = self.write_token

--- a/src/zeit/brightcove/tests/test_connection.py
+++ b/src/zeit/brightcove/tests/test_connection.py
@@ -1,4 +1,7 @@
 # coding: utf-8
+from StringIO import StringIO
+import json
+import mock
 import unittest
 import zeit.brightcove.connection
 
@@ -27,3 +30,24 @@ class ConnectionTest(unittest.TestCase):
             None, None, None, None, None)
         response = conn.parse_json(u'{"föö": "\u007f"}'.encode('utf-8'))
         self.assertEqual('', response[u'föö'])
+
+    def test_post_writes_to_the_configured_url(self):
+        conn = zeit.brightcove.connection.APIConnection(
+            None, 'my-write-token', None, 'http://write.url', 4711.0)
+        with mock.patch('urllib2.urlopen') as urlopen:
+            urlopen.return_value = StringIO(json.dumps({'result': 'okay'}))
+            result = conn.post('my-command', arg1='foo', arg2=42)
+        self.assertEqual((
+            ('http://write.url',
+             'json=%7B%22params%22%3A+%7B%22arg1%22%3A+%22foo%22%2C+%22arg2'
+             '%22%3A+42%2C+%22token%22%3A+%22my-write-token%22%7D%2C+%22method'
+             '%22%3A+%22my-command%22%7D'),
+            dict(timeout=4711.0)), urlopen.call_args)
+        self.assertEqual(u'okay', result)
+
+    def test_post_does_nothing_if_write_token_is_disabled(self):
+        conn = zeit.brightcove.connection.APIConnection(
+            None, 'disabled', None, None, None)
+        with mock.patch('urllib2.urlopen') as urlopen:
+            conn.post('my-command', arg1='foo', arg2=42)
+        self.assertFalse(urlopen.called)


### PR DESCRIPTION
Note: the batou deployment uses `disabled` instead of `invalid` as default for write tokens.
