### PR TITLE
BUG-790: Import changes to inactive videos, too

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.brightcove changes
 2.10.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- BUG-790: Import changes to inactive videos, too
 
 
 2.10.7 (2017-08-10)

--- a/src/zeit/brightcove/tests/test_update.py
+++ b/src/zeit/brightcove/tests/test_update.py
@@ -99,6 +99,17 @@ class ImportVideoTest(zeit.cms.testing.FunctionalTestCase):
         info = zeit.cms.workflow.interfaces.IPublishInfo(video)
         self.assertEqual(False, info.published)
 
+    def test_changes_to_inactive_video_should_be_imported(self):
+        bc = self.create_video()
+        import_video(bc)
+        bc.data['name'] = 'changed'
+        bc.data['state'] = 'INACTIVE'
+        import_video(bc)
+        video = ICMSContent('http://xml.zeit.de/video/2017-05/myvid')
+        self.assertEqual('changed', video.title)
+        info = zeit.cms.workflow.interfaces.IPublishInfo(video)
+        self.assertEqual(False, info.published)
+
     def test_deleted_video_should_be_deleted_from_cms(self):
         bc = self.create_video()
         import_video(bc)

--- a/src/zeit/brightcove/update.py
+++ b/src/zeit/brightcove/update.py
@@ -29,8 +29,7 @@ class import_video(object):
         self.cmsobj = zeit.cms.interfaces.ICMSContent(
             self.bcobj.uniqueId, None)
         log.debug('CMS object resolved: %r', self.cmsobj)
-        success = (self.delete() or self.deactivate() or
-                   self.add() or self.update())
+        success = (self.delete() or self.add() or self.update())
         if not success:
             log.warning('Not processed: %s', self.bcobj.uniqueId)
 
@@ -44,14 +43,6 @@ class import_video(object):
         if IPublishInfo(self.cmsobj).published:
             IPublish(self.cmsobj).retract(async=False)
         del self.bcobj.__parent__[self.bcobj.id]
-        return True
-
-    def deactivate(self):
-        if self.bcobj.state != 'INACTIVE' or self.cmsobj is None:
-            return False
-        log.info('Deactivating %s', self.bcobj)
-        if IPublishInfo(self.cmsobj).published:
-            IPublish(self.cmsobj).retract(async=False)
         return True
 
     def add(self):
@@ -76,6 +67,10 @@ class import_video(object):
         self._update()
         if self.bcobj.state == 'ACTIVE':
             IPublish(self.cmsobj).publish(async=False)
+        else:
+            log.info('Deactivating %s', self.bcobj)
+            if IPublishInfo(self.cmsobj).published:
+                IPublish(self.cmsobj).retract(async=False)
 
     def _update(self):
         log.info('Updating %s', self.bcobj)


### PR DESCRIPTION
Note that these changes will not show up in the vivi solr results,
since update() checks in without events, and of course there's no
subsequent publish, so there is no point where solr would be updated.