### PR TITLE
BUG-747: Implement playback API connection to retrieve media data

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.brightcove changes
 =======================
 
-2.11.1 (unreleased)
+2.12.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- BUG-747: Implement playback API connection to retrieve media data
 
 
 2.11.0 (2017-10-04)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.brightcove',
-    version='2.11.1.dev0',
+    version='2.12.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'setuptools',
         'zeit.addcentral',
         'zeit.cms >= 3.0.dev0',
-        'zeit.content.video>=2.8.0.dev0',
+        'zeit.content.video>=3.0.0.dev0',
         'zeit.solr>=2.2.0.dev0',
         'zope.cachedescriptors',
         'zope.component',

--- a/src/zeit/brightcove/__init__.py
+++ b/src/zeit/brightcove/__init__.py
@@ -1,15 +1,1 @@
-from zeit.brightcove.interfaces import DAV_NAMESPACE
-from zeit.cms.content.dav import DAVProperty
-from zeit.cms.i18n import MessageFactory as _
-import zeit.content.video.video
-import zope.schema
-
-
-zeit.content.video.video.Video.brightcove_id = DAVProperty(
-    zope.schema.TextLine(
-        title=_('Brightcove Id'),
-        readonly=True,
-    ),
-    DAV_NAMESPACE,
-    'id',
-)
+# python package

--- a/src/zeit/brightcove/configure.zcml
+++ b/src/zeit/brightcove/configure.zcml
@@ -19,7 +19,12 @@
 
   <utility
     provides="zeit.brightcove.interfaces.ICMSAPI"
-    factory=".connection.from_product_config"
+    factory=".connection.cms_from_product_config"
+    />
+
+  <utility
+    provides="zeit.content.video.interfaces.IPlayer"
+    factory=".connection.playback_from_product_config"
     />
 
   <subscriber

--- a/src/zeit/brightcove/convert.py
+++ b/src/zeit/brightcove/convert.py
@@ -146,7 +146,7 @@ class Video(Converter):
         data = self.data
         custom = data.get('custom_fields', {})
 
-        cmsobj.brightcove_id = data.get('id')
+        cmsobj.external_id = data.get('id')
         cmsobj.title = data.get('name')
         cmsobj.teaserText = data.get('description')
         cmsobj.subtitle = data.get('long_description')

--- a/src/zeit/brightcove/convert.py
+++ b/src/zeit/brightcove/convert.py
@@ -170,10 +170,6 @@ class Video(Converter):
         cmsobj.serie = IVideo['serie'].source(None).find(custom.get('serie'))
         cmsobj.supertitle = custom.get('supertitle')
         cmsobj.video_still_copyright = custom.get('credit')
-        cmsobj.thumbnail = data.get(
-            'images', {}).get('thumbnail', {}).get('src')
-        cmsobj.video_still = data.get(
-            'images', {}).get('poster', {}).get('src')
 
         product_source = IVideo['product'].source(cmsobj)
         if not custom.get('produkt-id') and data.get('reference_id'):
@@ -223,17 +219,6 @@ class Video(Converter):
         zeit.cms.content.interfaces.ISemanticChange(
             cmsobj).last_semantic_change = self.cms_date(
                 data.get('updated_at'))
-
-        renditions = []
-        for item in data.get('sources', ()):
-            vr = zeit.content.video.video.VideoRendition()
-            vr.url = item.get('src')
-            if not vr.url:
-                continue
-            vr.frame_width = item.get('width')
-            vr.video_duration = item.get('duration')
-            renditions.append(vr)
-        cmsobj.renditions = renditions
 
     def _default_if_missing(self, data, key, field, convert=None):
         if key not in data:

--- a/src/zeit/brightcove/interfaces.py
+++ b/src/zeit/brightcove/interfaces.py
@@ -1,9 +1,6 @@
 import zope.interface
 
 
-DAV_NAMESPACE = 'http://namespaces.zeit.de/CMS/brightcove'
-
-
 class ICMSAPI(zope.interface.Interface):
     """Brightcove CMS-API connection."""
 

--- a/src/zeit/brightcove/resolve.py
+++ b/src/zeit/brightcove/resolve.py
@@ -10,6 +10,7 @@ import zope.component
 log = logging.getLogger(__name__)
 
 
+# Defined in zeit.content.video.video.Video.external_id
 BRIGHTCOVE_ID = zeit.connector.search.SearchVar(
     'id', 'http://namespaces.zeit.de/CMS/brightcove')
 

--- a/src/zeit/brightcove/testing.py
+++ b/src/zeit/brightcove/testing.py
@@ -16,6 +16,11 @@ product_config = """\
     client-id none
     client-secret none
     timeout 300
+
+    playback-url none
+    playback-policy-key none
+    playback-timeout 3
+
     video-folder video
     playlist-folder video/playlist
     index-principal zope.user
@@ -50,8 +55,12 @@ class BrightcoveLayer(plone.testing.Layer):
         self.cmsapi_patch = mock.patch(
             'zeit.brightcove.connection.CMSAPI._request')
         self.cmsapi_patch.start()
+        self.playbackapi_patch = mock.patch(
+            'zeit.brightcove.connection.PlaybackAPI._request')
+        self.playbackapi_patch.start()
 
     def tearDown(self):
         self.cmsapi_patch.stop()
+        self.playbackapi_patch.stop()
 
 LAYER = BrightcoveLayer()

--- a/src/zeit/brightcove/tests/test_connection.py
+++ b/src/zeit/brightcove/tests/test_connection.py
@@ -11,17 +11,23 @@ class APIIntegration(unittest.TestCase):
 
     level = 2
 
-    def setUp(self):
-        self.api = zeit.brightcove.connection.CMSAPI(
+    def test_invalid_accesstoken_refreshes_and_retries_request(self):
+        api = zeit.brightcove.connection.CMSAPI(
             'https://cms.api.brightcove.com/v1/accounts/18140073001',
             'https://oauth.brightcove.com/v4',
             os.environ.get('ZEIT_BRIGHTCOVE_CLIENT_ID'),
             os.environ.get('ZEIT_BRIGHTCOVE_CLIENT_SECRET'),
             timeout=2)
-
-    def test_invalid_accesstoken_refreshes_and_retries_request(self):
-        data = self.api._request('GET /video_fields')
+        data = api._request('GET /video_fields')
         self.assertIn('custom_fields', data.keys())
+
+    def test_playback_api_authenticates_with_policy_key(self):
+        api = zeit.brightcove.connection.PlaybackAPI(
+            'https://edge.api.brightcove.com/playback/v1/accounts/18140073001',
+            os.environ.get('ZEIT_BRIGHTCOVE_POLICY_KEY'),
+            timeout=2)
+        data = api._request('GET /videos/5622601784001')
+        assert 'zeitmagazin' in data['tags']
 
 
 class CMSAPI(unittest.TestCase):
@@ -82,3 +88,29 @@ class CMSAPI(unittest.TestCase):
                 2, request.call_args_list[2][1]['params']['offset'])
             self.assertEqual(
                 5, request.call_args_list[3][1]['params']['offset'])
+
+
+class PlayerAPI(unittest.TestCase):
+
+    def test_converts_sources(self):
+        api = zeit.brightcove.connection.PlaybackAPI('', '', None)
+        with mock.patch.object(api, '_request') as request:
+            request.return_value = {'sources': [{
+                'asset_id': '83006421001',
+                'codec': 'H264',
+                'container': 'MP4',
+                'duration': 85163,
+                'encoding_rate': 1264000,
+                'height': 720,
+                'remote': False,
+                'size': 13453446,
+                'src': 'https://brightcove.hs.llnwd.net/e1/pd/...',
+                'uploaded_at': '2010-05-05T08:26:48.704Z',
+                'width': 1280,
+            }]}
+            data = api.get_video('myid')
+        self.assertEqual(1, len(data['renditions']))
+        src = data['renditions'][0]
+        self.assertEqual(1280, src.frame_width)
+        self.assertEqual('https://brightcove.hs.llnwd.net/e1/pd/...', src.url)
+        self.assertEqual(85163, src.video_duration)

--- a/src/zeit/brightcove/tests/test_convert.py
+++ b/src/zeit/brightcove/tests/test_convert.py
@@ -109,30 +109,6 @@ class VideoTest(zeit.cms.testing.FunctionalTestCase,
         bc = BCVideo.from_cms(cms)
         self.assertEqual('FREE', bc.data['economics'])
 
-    def test_converts_sources(self):
-        bc = BCVideo()
-        bc.data['sources'] = [{
-            'asset_id': '83006421001',
-            'codec': 'H264',
-            'container': 'MP4',
-            'duration': 85163,
-            'encoding_rate': 1264000,
-            'height': 720,
-            'remote': False,
-            'size': 13453446,
-            'src': 'https://brightcove.hs.llnwd.net/e1/pd/...',
-            'uploaded_at': '2010-05-05T08:26:48.704Z',
-            'width': 1280,
-        }]
-        cms = CMSVideo()
-        bc.apply_to_cms(cms)
-        sources = cms.renditions
-        self.assertEqual(1, len(sources))
-        src = sources[0]
-        self.assertEqual(1280, src.frame_width)
-        self.assertEqual('https://brightcove.hs.llnwd.net/e1/pd/...', src.url)
-        self.assertEqual(85163, src.video_duration)
-
     def test_converts_timestamps(self):
         bc = BCVideo()
         bc.data['created_at'] = '2017-05-15T08:24:55.916Z'
@@ -197,9 +173,6 @@ class VideoTest(zeit.cms.testing.FunctionalTestCase,
                 'http://xml.zeit.de/online/2007/01/eta-zapatero'),),
             zeit.cms.related.interfaces.IRelatedContent(cms).related)
         self.assertEqual('erde/umwelt', cms.serie.serienname)
-        self.assertEqual('http://example.com/thumbnail', cms.thumbnail)
-        self.assertEqual('http://example.com/still', cms.video_still)
-        self.assertEqual('http://example.com/rendition', cms.renditions[0].url)
 
     def test_creates_deleted_video_on_notfound(self):
         with mock.patch('zeit.brightcove.connection.CMSAPI.get_video') as get:

--- a/src/zeit/brightcove/tests/test_convert.py
+++ b/src/zeit/brightcove/tests/test_convert.py
@@ -181,7 +181,7 @@ class VideoTest(zeit.cms.testing.FunctionalTestCase,
             }],
         }
         bc.apply_to_cms(cms)
-        self.assertEqual('myvid', cms.brightcove_id)
+        self.assertEqual('myvid', cms.external_id)
         self.assertEqual('title', cms.title)
         self.assertEqual(True, cms.commentsAllowed)
         self.assertEqual(['http://xml.zeit.de/a1'],


### PR DESCRIPTION
Since image and video URLs are only valid for a maximum of 6h, we cannot import them once into vivi and then forget, we need to retrieve them live on access.

Needs https://github.com/ZeitOnline/zeit.content.video/pull/11